### PR TITLE
Backport afi23 fixes

### DIFF
--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -336,8 +336,6 @@ impl MoodleFetcher {
         }
 
         info!("done");
-        warn!("note: repacking autofetched files is not implemented yet!");
-
         Ok(())
     }
     fn gen_grading_files(

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -351,7 +351,7 @@ impl MoodleFetcher {
 
         groups.iter().for_each(|(&gid, &gname)| {
             grades_arr.push(Grade {
-                grade: "0".to_string(),
+                grade: "".to_string(),
                 internal_id: Some(gid.to_owned()),
                 members: group_user_mappings.get(gid).cloned(),
                 target: gname.to_owned(),
@@ -404,6 +404,11 @@ impl MoodleFetcher {
             let gname = userdata.get("groupname").unwrap().as_str().unwrap();
 
             info!("dry-run: would set {grade} for ({uname}) AND Group ({gname})");
+            return Ok(());
+        }
+
+        if grade.is_empty() {
+            warn!("skipping {userid} because of empty grade");
             return Ok(());
         }
 

--- a/src/grade.rs
+++ b/src/grade.rs
@@ -11,7 +11,7 @@ pub fn grade(master: &MasterCfg, cfg: &GradeCmd, grades: &Grades) -> Result<(), 
         Some(str) => str.clone(),
         None => {
             let cd = std::env::current_dir()?;
-            let infer = cd.components().find_map(|c| {
+            let infer = cd.components().rev().find_map(|c| {
                 reg.captures(c.as_os_str().to_str().unwrap())
                     .and_then(|caps| caps.get(2).map(|c| c.as_str()))
             });


### PR DESCRIPTION
**Fixes**
- When inferring groups, the dirtree was being searched top to bottom. This would result in bad inferred group numbers, in the case that a preceding directory name had similar content. The dirtree will be searched bottom-up from now on.
- In `kasm push`, unset grades in the slave cfg will no longer be set to 0, but rather omitted.
- Removed an outdated warning.